### PR TITLE
Add indentation check workflow

### DIFF
--- a/.github/workflows/indent.yml
+++ b/.github/workflows/indent.yml
@@ -1,0 +1,22 @@
+name: Indent Check
+on:
+  pull_request:
+    paths:
+      - '**/*.el'
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  indent:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: purcell/setup-emacs@master
+        with:
+          version: 29.3
+      - name: Check indentation
+        run: ./scripts/check-indent.sh

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # op.el
 1password integration for Emacs
+
+This repository uses GitHub Actions to run ERT tests and to verify that all
+Emacs Lisp files are properly indented. The indentation check can also be run
+locally via `./scripts/check-indent.sh`.

--- a/scripts/check-indent.sh
+++ b/scripts/check-indent.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Check Emacs Lisp files are properly indented
+
+files=$(git ls-files '*.el')
+status=0
+
+for file in $files; do
+  emacs --batch "$file" \
+        --eval "(indent-region (point-min) (point-max))" \
+        -f save-buffer
+done
+
+if ! git diff --quiet; then
+  echo "Indentation issues found in the following files:" >&2
+  git diff --name-only >&2
+  status=1
+fi
+
+git checkout -- $files
+exit $status


### PR DESCRIPTION
## Summary
- add a script that verifies all Emacs Lisp files are properly indented
- add a GitHub Actions workflow that runs the indentation check on PRs and pushes to main
- document the new workflow in the README

## Testing
- `./scripts/run-tests.sh`
- `./scripts/check-indent.sh`


------
https://chatgpt.com/codex/tasks/task_e_6850eef0926483309d16bdd51f060cf8