### PR TITLE
Switch to Cask for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,9 +19,5 @@ jobs:
       image: silex/emacs:${{ matrix.emacs_version }}-ci-cask
     steps:
       - uses: actions/checkout@v4
-      - name: Install git and make
-        run: |
-          apt-get update -y
-          apt-get install -y git make sudo
       - name: Run tests
         run: ./scripts/run-tests.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,6 @@ jobs:
         run: |
           git clone --depth 1 https://github.com/cask/cask
           make -C cask
-          sudo make -C cask installgi
+          sudo make -C cask install
       - name: Run tests
         run: ./scripts/run-tests.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,10 @@ jobs:
       image: silex/emacs:${{ matrix.emacs_version }}
     steps:
       - uses: actions/checkout@v4
+      - name: Install git
+        run: |
+          apt-get update -y
+          apt-get install -y git
       - name: Install Cask
         run: |
           git clone --depth 1 https://github.com/cask/cask

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Install Cask
         run: |
           git clone --depth 1 https://github.com/cask/cask
-          make -C cask install
+          make -C cask
+          sudo make -C cask install
       - name: Run tests
         run: ./scripts/run-tests.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,11 +22,11 @@ jobs:
       - name: Install git and make
         run: |
           apt-get update -y
-          apt-get install -y git make
+          apt-get install -y git make sudo
       - name: Install Cask
         run: |
           git clone --depth 1 https://github.com/cask/cask
           make -C cask
-          sudo make -C cask install
+          sudo make -C cask installgi
       - name: Run tests
         run: ./scripts/run-tests.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,5 +19,9 @@ jobs:
       image: silex/emacs:${{ matrix.emacs_version }}
     steps:
       - uses: actions/checkout@v4
+      - name: Install Cask
+        run: |
+          git clone --depth 1 https://github.com/cask/cask
+          make -C cask install
       - name: Run tests
         run: ./scripts/run-tests.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,10 +19,10 @@ jobs:
       image: silex/emacs:${{ matrix.emacs_version }}
     steps:
       - uses: actions/checkout@v4
-      - name: Install git
+      - name: Install git and make
         run: |
           apt-get update -y
-          apt-get install -y git
+          apt-get install -y git make
       - name: Install Cask
         run: |
           git clone --depth 1 https://github.com/cask/cask

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,17 +16,12 @@ jobs:
       matrix:
         emacs_version: ["29.3", "30.1"]
     container:
-      image: silex/emacs:${{ matrix.emacs_version }}
+      image: silex/emacs:${{ matrix.emacs_version }}-ci-cask
     steps:
       - uses: actions/checkout@v4
       - name: Install git and make
         run: |
           apt-get update -y
           apt-get install -y git make sudo
-      - name: Install Cask
-        run: |
-          git clone --depth 1 https://github.com/cask/cask
-          make -C cask
-          sudo make -C cask install
       - name: Run tests
         run: ./scripts/run-tests.sh

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.elc
 
 # Packaging
+cask/
 .cask/
 .eask/
 .eldev/

--- a/Cask
+++ b/Cask
@@ -1,0 +1,5 @@
+(source gnu)
+(source melpa)
+
+(development
+(depends-on "buttercup"))

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@
 
 1Password integration for Emacs
 
-This repository uses GitHub Actions to run ERT tests and to verify that all
-Emacs Lisp files are properly indented. The indentation check can also be run
-locally via `./scripts/check-indent.sh`.
+This repository uses GitHub Actions to run Buttercup tests and to verify that all Emacs Lisp files are properly indented. The indentation check can also be run locally via `./scripts/check-indent.sh`.
+
+## Contributing
+
+Write unit tests with [Buttercup](https://github.com/jorgenschaefer/emacs-buttercup) and name each spec using the pattern **X when Y should Z**.
+
+Install the development dependencies with [Cask](https://cask.readthedocs.io/en/latest/) and run the suite via `./scripts/run-tests.sh` before submitting a pull request.

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Run the ERT suite
-emacs --batch -Q -L . -l test/run-tests.el
+# Install dependencies and run the Buttercup suite
+cask install
+cask exec emacs --batch -Q -L . -L test -l test/run-tests.el

--- a/test/op-test.el
+++ b/test/op-test.el
@@ -1,24 +1,28 @@
-(require 'ert)
+;;; op-test.el --- unit tests -*- lexical-binding: t; -*-
+
+(require 'buttercup)
 (load-file "op.el")
 
-(ert-deftest op-read-caches-result ()
-  (let ((op-read-cache (make-hash-table :test 'equal))
-        (called 0))
-    (cl-letf (((symbol-function 'shell-command-to-string)
-               (lambda (&rest _)
-                 (setq called (1+ called))
-                 "secret")))
-      (should (string= (op-read "item") "secret"))
-      (should (= called 1))
-      (should (string= (op-read "item") "secret"))
-      (should (= called 1)))))
+(describe "op-read"
+	  (it "when called twice should use the cached result"
+	      (let ((op-read-cache (make-hash-table :test 'equal))
+		    (called 0))
+		(spy-on 'shell-command-to-string
+			:and-call-fake (lambda (&rest _)
+					 (setq called (1+ called))
+					 "secret"))
+		(expect (op-read "item") :to-equal "secret")
+		(expect called :to-equal 1)
+		(expect (op-read "item") :to-equal "secret")
+		(expect called :to-equal 1))))
 
-(ert-deftest op-read-cache-cleanup-removes-old-entries ()
-  (let ((op-read-cache (make-hash-table :test 'equal)))
-    (puthash "old" (cons "val" (- (float-time) (* 11 60))) op-read-cache)
-    (puthash "recent" (cons "val" (float-time)) op-read-cache)
-    (op-read-cache-cleanup)
-    (should-not (gethash "old" op-read-cache))
-    (should (gethash "recent" op-read-cache))))
+(describe "op-read-cache-cleanup"
+	  (it "when run should remove expired entries"
+	      (let ((op-read-cache (make-hash-table :test 'equal)))
+		(puthash "old" (cons "val" (- (float-time) (* 11 60))) op-read-cache)
+		(puthash "recent" (cons "val" (float-time)) op-read-cache)
+		(op-read-cache-cleanup)
+		(expect (gethash "old" op-read-cache) :to-be nil)
+		(expect (gethash "recent" op-read-cache) :not :to-be nil))))
 
 (provide 'op-test)

--- a/test/run-tests.el
+++ b/test/run-tests.el
@@ -1,6 +1,10 @@
+;;; run-tests.el --- run Buttercup suite -*- lexical-binding: t; -*-
+
 (let* ((script-dir (file-name-directory (or load-file-name buffer-file-name)))
        (root-dir (expand-file-name ".." script-dir)))
   (add-to-list 'load-path root-dir)
+  (add-to-list 'load-path script-dir)
+  (require 'buttercup)
   (load (expand-file-name "op-test.el" script-dir)))
 
-(ert-run-tests-batch-and-exit)
+(buttercup-run)


### PR DESCRIPTION
## Summary
- use Cask to install Buttercup
- remove vendored Buttercup sources
- document Cask usage in README
- update test runner and CI workflow

## Testing
- `./scripts/check-indent.sh`
- `./scripts/run-tests.sh` *(fails: network access to elpa.gnu.org and melpa.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6852b70dcac0833087e243d969cd6c97