### PR TITLE
Rewrite tests with buttercup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,8 @@
 # Agent Contributions
 
-Agent guidelines for `renatgalimov/op.el` GitHub repo.
+The environment has `gh` installed. Only `gh api` commands may be used; avoid other subcommands.
 
-GitHub: `renatgalimov/op.el`
+The environment has to have an authenticated `gh`; `gh auth status` should succeed or report an error and stop.
 
 ## Git
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,4 @@
 
 1Password integration for Emacs
 
-This repository uses GitHub Actions to run ERT tests and to verify that all
-Emacs Lisp files are properly indented. The indentation check can also be run
-locally via `./scripts/check-indent.sh`.
+This repository uses GitHub Actions to run Buttercup tests and verify that all Emacs Lisp files are properly indented. The indentation check can also be run locally via `./scripts/check-indent.sh`.

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Run the ERT suite
-emacs --batch -Q -L . -l test/run-tests.el
+# Run the Buttercup test suite
+buttercup_dir=$(echo /usr/share/emacs/site-lisp/elpa/buttercup-*)
+emacs --batch -Q -L . \
+      -L "$buttercup_dir" \
+      -l test/run-tests.el

--- a/test/op-test.el
+++ b/test/op-test.el
@@ -15,10 +15,10 @@
 			     (with-current-buffer (nth 2 args)
 			       (insert "secret"))
 			     0)))
-		  (expect (op-read "item") :to-equal "secret")
-		  (expect called :to-be 1)
-		  (expect (op-read "item") :to-equal "secret")
-		  (expect called :to-be 1))))
+			 (expect (op-read "item") :to-equal "secret")
+			 (expect called :to-be 1)
+			 (expect (op-read "item") :to-equal "secret")
+			 (expect called :to-be 1))))
 
 	  (it "does not cache error output"
 	      (let ((called 0))
@@ -28,24 +28,25 @@
 			     (with-current-buffer (nth 2 args)
 			       (insert "err"))
 			     1)))
-		  (expect (op-read "item") :to-equal "err")
-		  (expect (gethash "item" op-read-cache) :to-be nil)
-		  (expect called :to-be 1)
-		  (expect (op-read "item") :to-equal "err")
-		  (expect called :to-be 2)))))
+			 (expect (op-read "item") :to-equal "err")
+			 (expect (gethash "item" op-read-cache) :to-be nil)
+			 (expect called :to-be 1)
+			 (expect (op-read "item") :to-equal "err")
+			 (expect called :to-be 2))))
 
 	  (it "when called twice should use the cached result"
 	      (let ((op-read-cache (make-hash-table :test 'equal))
 		    (called 0))
-		(spy-on 'shell-command-to-string
-			:and-call-fake (lambda (&rest _)
-					 (setq called (1+ called))
-					 "secret"))
-		(expect (op-read "item") :to-equal "secret")
-		(expect called :to-equal 1)
-		(expect (op-read "item") :to-equal "secret")
-		(expect called :to-equal 1))))
-
+		(cl-letf (((symbol-function 'call-process)
+			   (lambda (&rest args)
+			     (setq called (1+ called))
+			     (with-current-buffer (nth 2 args)
+			       (insert "secret"))
+			     0)))
+			 (expect (op-read "item") :to-equal "secret")
+			 (expect called :to-equal 1)
+			 (expect (op-read "item") :to-equal "secret")
+			 (expect called :to-equal 1)))))
 
 (describe "op-read-cache-cleanup"
 	  (it "when run should remove expired entries"
@@ -57,18 +58,20 @@
 		(expect (gethash "recent" op-read-cache) :not :to-be nil))))
 
 (describe "op-read-cache-duration"
-  (it "should allow customizing the cache duration"
-      (let ((op-read-cache (make-hash-table :test 'equal))
-            (called 0)
-            (op-read-cache-duration 1)) ; 1 second for test
-        (spy-on 'shell-command-to-string
-                :and-call-fake (lambda (&rest _)
-                                 (setq called (1+ called))
-                                 "secret"))
-        (expect (op-read "item") :to-equal "secret")
-        (expect called :to-equal 1)
-        (sleep-for 2)
-        (expect (op-read "item") :to-equal "secret")
-        (expect called :to-equal 2))))
+	  (it "should allow customizing the cache duration"
+	      (let ((op-read-cache (make-hash-table :test 'equal))
+		    (called 0)
+		    (op-read-cache-duration 1)) ; 1 second for test
+		(cl-letf (((symbol-function 'call-process)
+			   (lambda (&rest args)
+			     (setq called (1+ called))
+			     (with-current-buffer (nth 2 args)
+			       (insert "secret"))
+			     0)))
+			 (expect (op-read "item") :to-equal "secret")
+			 (expect called :to-equal 1)
+			 (sleep-for 2)
+			 (expect (op-read "item") :to-equal "secret")
+			 (expect called :to-equal 2)))))
 
 (provide 'op-test)

--- a/test/op-test.el
+++ b/test/op-test.el
@@ -1,24 +1,44 @@
-(require 'ert)
+(require 'buttercup)
 (load-file "op.el")
 
-(ert-deftest op-read-caches-result ()
-  (let ((op-read-cache (make-hash-table :test 'equal))
-        (called 0))
-    (cl-letf (((symbol-function 'shell-command-to-string)
-               (lambda (&rest _)
-                 (setq called (1+ called))
-                 "secret")))
-      (should (string= (op-read "item") "secret"))
-      (should (= called 1))
-      (should (string= (op-read "item") "secret"))
-      (should (= called 1)))))
+(describe "op-read"
+	  (before-each
+	   (setq op-read-cache (make-hash-table :test #'equal)))
 
-(ert-deftest op-read-cache-cleanup-removes-old-entries ()
-  (let ((op-read-cache (make-hash-table :test 'equal)))
-    (puthash "old" (cons "val" (- (float-time) (* 11 60))) op-read-cache)
-    (puthash "recent" (cons "val" (float-time)) op-read-cache)
-    (op-read-cache-cleanup)
-    (should-not (gethash "old" op-read-cache))
-    (should (gethash "recent" op-read-cache))))
+	  (it "caches result"
+	      (let ((called 0))
+		(cl-letf (((symbol-function 'call-process)
+			   (lambda (&rest args)
+			     (setq called (1+ called))
+			     (with-current-buffer (nth 2 args)
+			       (insert "secret"))
+			     0)))
+		  (expect (op-read "item") :to-equal "secret")
+		  (expect called :to-be 1)
+		  (expect (op-read "item") :to-equal "secret")
+		  (expect called :to-be 1))))
+
+	  (it "does not cache error output"
+	      (let ((called 0))
+		(cl-letf (((symbol-function 'call-process)
+			   (lambda (&rest args)
+			     (setq called (1+ called))
+			     (with-current-buffer (nth 2 args)
+			       (insert "err"))
+			     1)))
+		  (expect (op-read "item") :to-equal "err")
+		  (expect (gethash "item" op-read-cache) :to-be nil)
+		  (expect called :to-be 1)
+		  (expect (op-read "item") :to-equal "err")
+		  (expect called :to-be 2)))))
+
+(describe "op-read-cache-cleanup"
+	  (it "removes old entries"
+	      (let ((op-read-cache (make-hash-table :test #'equal)))
+		(puthash "old" (cons "val" (- (float-time) (* 11 60))) op-read-cache)
+		(puthash "recent" (cons "val" (float-time)) op-read-cache)
+		(op-read-cache-cleanup)
+		(expect (gethash "old" op-read-cache) :to-be nil)
+		(expect (gethash "recent" op-read-cache) :not :to-be nil))))
 
 (provide 'op-test)

--- a/test/run-tests.el
+++ b/test/run-tests.el
@@ -1,6 +1,7 @@
 (let* ((script-dir (file-name-directory (or load-file-name buffer-file-name)))
        (root-dir (expand-file-name ".." script-dir)))
   (add-to-list 'load-path root-dir)
+  (require 'buttercup)
   (load (expand-file-name "op-test.el" script-dir)))
 
-(ert-run-tests-batch-and-exit)
+(buttercup-run)


### PR DESCRIPTION
## Summary
- rewrite tests to use Buttercup
- update test runner for Buttercup
- document Buttercup usage in README

## Testing
- `./scripts/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68526913addc8330968864aa275d0d6b