### PR TITLE
Create new 1Password items via auth-source `:create`

### DIFF
--- a/bin/op.py
+++ b/bin/op.py
@@ -139,10 +139,10 @@ def fixture_path(argv):
         template = json.loads(stdin_data)
         title = template.get("title", "")
         vault = None
-        it = iter(rest)
-        for arg in it:
+        arg_iter = iter(rest)
+        for arg in arg_iter:
             if arg == "--vault":
-                vault = next(it, None)
+                vault = next(arg_iter, None)
             elif arg.startswith("--vault="):
                 vault = arg.split("=", 1)[1]
         parts = ["item-create"]

--- a/bin/op.py
+++ b/bin/op.py
@@ -121,6 +121,38 @@ def fixture_path(argv):
             name += f"-{extra}"
         return FIXTURE_DIR / f"{account_prefix}{name}.{ext}", stdin_data
 
+    if cmd == "vault/list":
+        suffix = args_to_suffix(rest)
+        name = "vault-list"
+        if suffix:
+            name += f"-{suffix}"
+        return FIXTURE_DIR / f"{account_prefix}{name}.json", stdin_data
+
+    if cmd == "item/create":
+        if "-" not in rest:
+            print(
+                "item create: only stdin templates are supported in mock mode (use `-`)",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        stdin_data = sys.stdin.read()
+        template = json.loads(stdin_data)
+        title = template.get("title", "")
+        vault = None
+        it = iter(rest)
+        for arg in it:
+            if arg == "--vault":
+                vault = next(it, None)
+            elif arg.startswith("--vault="):
+                vault = arg.split("=", 1)[1]
+        parts = ["item-create"]
+        if vault:
+            parts.append(vault)
+        if title:
+            parts.append(title)
+        name = "-".join(parts)
+        return FIXTURE_DIR / f"{account_prefix}{name}.json", stdin_data
+
     if cmd.startswith("read/"):
         ref = args[1] if len(args) > 1 else None
         if not ref:

--- a/op-auth-source.el
+++ b/op-auth-source.el
@@ -144,12 +144,14 @@ Builds a JSON template tagged with `op-auth-source-tag' and pipes it
 to `op --account ACCOUNT item create --vault VAULT'.  Returns the
 parsed item alist on success.  Signals an error and pops up
 `*op-error*' on failure."
-  (let* ((template (op-auth-source--build-template
+  (let* ((extras (op-auth-source--extra-fields fields))
+         (template (op-auth-source--build-template
                     op-auth-source-tag
                     (plist-get fields :host)
                     (plist-get fields :user)
                     (plist-get fields :port)
-                    (plist-get fields :secret)))
+                    (plist-get fields :secret)
+                    extras))
          (result (op-run (list "--account" account
                                "item" "create"
                                "--vault" vault
@@ -167,8 +169,18 @@ parsed item alist on success.  Signals an error and pops up
                      (plist-get fields :host)
                      (plist-get fields :user)
                      (plist-get fields :port)
-                     op-auth-source--redacted-secret))
+                     op-auth-source--redacted-secret
+                     extras))
     (json-read-from-string (plist-get result :stdout))))
+
+(defun op-auth-source--extra-fields (fields)
+  "Return the entries of FIELDS beyond the base host/user/port/secret keys.
+FIELDS is the plist from `op-auth-source--prompt-fields'.  Returns a plist
+of the extra (KEYWORD VALUE ...) pairs requested via auth-source's `:create'
+list, in their original order."
+  (cl-loop for (key value) on fields by #'cddr
+           unless (memq key '(:host :user :port :secret))
+           append (list key value)))
 
 (defun op-auth-source--resolve-account ()
   "Pick a 1Password account UUID, prompting only if there are multiple."
@@ -360,10 +372,12 @@ Returns the label string, or nil if none match."
                      secret-label))
               op-auth-source--secret-labels)))
 
-(defun op-auth-source--build-template (tag host user port secret)
+(defun op-auth-source--build-template (tag host user port secret &optional extras)
   "Build a 1Password Login item JSON template string.
 TAG, HOST, USER and SECRET are required strings.  PORT is included
-as a custom field only when it is a non-empty string."
+as a custom field only when it is a non-empty string.  EXTRAS is a plist
+of (KEYWORD VALUE ...) for any additional fields the caller requested via
+auth-source's `:create' list; each is emitted as a custom STRING field."
   (let* ((base-fields
           (list `((id . "username") (type . "STRING") (purpose . "USERNAME")
                   (label . "username") (value . ,user))
@@ -374,12 +388,22 @@ as a custom field only when it is a non-empty string."
          (port-field (and port (not (string-empty-p port))
                           (list `((id . "port") (type . "STRING")
                                   (label . "port") (value . ,port)))))
-         (fields (vconcat base-fields port-field)))
+         (fields (vconcat base-fields port-field
+                          (op-auth-source--build-extra-fields extras))))
     (json-encode
      `((title . ,host)
        (category . "LOGIN")
        (tags . ,(vector tag))
        (fields . ,fields)))))
+
+(defun op-auth-source--build-extra-fields (extras)
+  "Build a list of custom STRING field alists from EXTRAS.
+EXTRAS is a plist of (KEYWORD VALUE ...); the keyword name without its
+leading colon becomes the field id and label."
+  (cl-loop for (key value) on extras by #'cddr
+           for label = (substring (symbol-name key) 1)
+           collect `((id . ,label) (type . "STRING")
+                     (label . ,label) (value . ,value))))
 
 (defun op-auth-source--get-secret (item-id account secret-label)
   "Fetch the SECRET-LABEL field for 1Password item ITEM-ID in ACCOUNT.

--- a/op-auth-source.el
+++ b/op-auth-source.el
@@ -211,13 +211,8 @@ list, in their original order."
   "List 1Password vaults visible to ACCOUNT.
 Returns a list of alists with vault details.
 Signals an error and pops up `*op-error*' on failure."
-  (let ((result (op-run (list "--account" account
-                              "vault" "list"
-                              "--format" "json"))))
-    (op--check-exit (plist-get result :exit-code)
-                    (plist-get result :stderr)
-                    (format "op --account %s vault list --format json" account))
-    (append (json-read-from-string (plist-get result :stdout)) nil)))
+  (op--run-json-list (list "--account" account "vault" "list" "--format" "json")
+                     (format "op --account %s vault list --format json" account)))
 
 (defun op-auth-source--prompt-fields (spec create)
   "Resolve required fields, prompting for any missing values.

--- a/op-auth-source.el
+++ b/op-auth-source.el
@@ -292,10 +292,12 @@ Comparison is case-insensitive for labels, exact for values."
 
 (defun op-auth-source--value-to-string (value)
   "Coerce VALUE to a string for field matching.
-Strings pass through; symbols are converted via `symbol-name'."
+Strings pass through; symbols are converted via `symbol-name'; a list
+resolves to its first element (auth-source \"any of these\" patterns)."
   (cond
    ((stringp value) value)
    ((symbolp value) (symbol-name value))
+   ((consp value) (op-auth-source--value-to-string (car value)))
    (t (format "%s" value))))
 
 (defun op-auth-source--match-item (item criteria)

--- a/op-auth-source.el
+++ b/op-auth-source.el
@@ -89,7 +89,7 @@ returned by `op-auth-source--match-item' with matched :host, :user, :port."
           :secret (lambda () (op-auth-source--get-secret id account-uuid secret-label)))))
 
 (cl-defun op-auth-source-search (&rest criteria
-                                       &key host user port
+                                       &key backend create
                                        (max 1)
                                        &allow-other-keys)
   "Search 1Password for credentials matching CRITERIA.
@@ -98,25 +98,151 @@ pair is matched against item fields by label.
 BACKEND and TYPE have their standard auth-source meanings.
 MAX limits the number of results (default 1).  When MAX is 0,
 returns t if any match exists, nil otherwise.
+When CREATE is non-nil and no items match, dispatches to BACKEND's
+`create-function' so the user can persist a new credential.
 Returns a list of plists with :host, :user, :port, and :secret."
   (op--log "search called with criteria: %S" criteria)
-  (cl-loop for item in (op--fetch-items op-auth-source-tag)
-           for resolved = (op-auth-source--match-item item criteria)
-           when resolved
-           collect (op-auth-source--make-result item resolved)
-           into results
-           finally return
-           (cond
-            ((null results) nil)
-            ((zerop max) t)
-            ((> (length results) max) (seq-take results max))
-            (t results))))
+  (or (cl-loop for item in (op--fetch-items op-auth-source-tag)
+               for resolved = (op-auth-source--match-item item criteria)
+               when resolved
+               collect (op-auth-source--make-result item resolved)
+               into results
+               finally return
+               (cond
+                ((null results) nil)
+                ((zerop max) t)
+                ((> (length results) max) (seq-take results max))
+                (t results)))
+      (and create backend
+           (apply (slot-value backend 'create-function) criteria))))
+
+(cl-defun op-auth-source-create (&rest spec
+                                       &key backend create
+                                       &allow-other-keys)
+  "Create a 1Password item to satisfy auth-source's `:create' request.
+Prompts for any missing required fields and returns a one-element list
+with a result plist whose `:save-function' runs `op item create'."
+  (ignore backend)
+  (let* ((account (op-auth-source--resolve-account))
+         (vault (op-auth-source--resolve-vault account))
+         (fields (op-auth-source--prompt-fields spec create)))
+    (list (list :host (plist-get fields :host)
+                :user (plist-get fields :user)
+                :port (plist-get fields :port)
+                :account account
+                :secret (lambda () (plist-get fields :secret))
+                :save-function (lambda ()
+                                 (op-auth-source--save-item account vault fields))))))
+
+(defun op-auth-source--save-item (account vault fields)
+  "Persist a new 1Password Login item.
+FIELDS is the plist returned by `op-auth-source--prompt-fields'.
+Builds a JSON template tagged with `op-auth-source-tag' and pipes it
+to `op --account ACCOUNT item create --vault VAULT'.  Returns the
+parsed item alist on success.  Signals an error and pops up
+`*op-error*' on failure."
+  (let* ((template (op-auth-source--build-template
+                    op-auth-source-tag
+                    (plist-get fields :host)
+                    (plist-get fields :user)
+                    (plist-get fields :port)
+                    (plist-get fields :secret)))
+         (result (op-run (list "--account" account
+                               "item" "create"
+                               "--vault" vault
+                               "--format" "json"
+                               "-")
+                         template)))
+    (op--check-exit (plist-get result :exit-code)
+                    (plist-get result :stderr)
+                    (format "op --account %s item create --vault %s --format json -"
+                            account vault)
+                    template)
+    (json-read-from-string (plist-get result :stdout))))
+
+(defun op-auth-source--resolve-account ()
+  "Pick a 1Password account UUID, prompting only if there are multiple."
+  (let ((accounts (op--list-accounts)))
+    (cond
+     ((null accounts) (error "No 1Password accounts available"))
+     ((null (cdr accounts)) (alist-get 'account_uuid (car accounts)))
+     (t (op-auth-source--prompt-account accounts)))))
+
+(defun op-auth-source--prompt-account (accounts)
+  "Prompt the user to choose from ACCOUNTS, returning the chosen UUID."
+  (let ((choices (mapcar (lambda (account)
+                           (cons (or (alist-get 'email account)
+                                     (alist-get 'account_uuid account))
+                                 (alist-get 'account_uuid account)))
+                         accounts)))
+    (cdr (assoc (completing-read "1Password account: " choices nil t) choices))))
+
+(defun op-auth-source--resolve-vault (account)
+  "Prompt the user to choose a vault from ACCOUNT, returning the vault name."
+  (let ((names (mapcar (lambda (vault) (alist-get 'name vault))
+                       (op-auth-source--list-vaults account))))
+    (when (null names)
+      (error "No 1Password vaults available for account %s" account))
+    (completing-read "1Password vault: " names nil t)))
+
+(defun op-auth-source--list-vaults (account)
+  "List 1Password vaults visible to ACCOUNT.
+Returns a list of alists with vault details.
+Signals an error and pops up `*op-error*' on failure."
+  (let ((result (op-run (list "--account" account
+                              "vault" "list"
+                              "--format" "json"))))
+    (op--check-exit (plist-get result :exit-code)
+                    (plist-get result :stderr)
+                    (format "op --account %s vault list --format json" account))
+    (append (json-read-from-string (plist-get result :stdout)) nil)))
+
+(defun op-auth-source--prompt-fields (spec create)
+  "Resolve required fields, prompting for any missing values.
+SPEC is the auth-source create spec.  CREATE may be t or a list of
+extra field symbols to require beyond `(host user port secret)'.
+Returns a plist with `:host', `:user', `:port', `:secret', plus any extras."
+  (let ((resolved nil))
+    (dolist (field (append '(host user port secret)
+                           (and (consp create) create)))
+      (setq resolved
+            (plist-put resolved
+                       (intern (concat ":" (symbol-name field)))
+                       (op-auth-source--resolve-field field spec resolved))))
+    resolved))
+
+(defun op-auth-source--resolve-field (field spec resolved)
+  "Resolve one FIELD from SPEC, falling back to a prompt.
+RESOLVED is the partial plist of fields collected so far, used to
+provide context to the prompt."
+  (let ((provided (plist-get spec (intern (concat ":" (symbol-name field))))))
+    (if (and provided (not (eq provided t)))
+        (op-auth-source--value-to-string provided)
+      (op-auth-source--prompt-for-field field resolved))))
+
+(defun op-auth-source--prompt-for-field (field resolved)
+  "Prompt the user for FIELD, given the partially RESOLVED plist.
+Uses `read-passwd' for `secret' and `read-string' for everything else.
+Signals an error if FIELD is not one of the recognized fields."
+  (cl-case field
+    (secret (read-passwd (format "1Password password for %s@%s: "
+                                 (or (plist-get resolved :user) "")
+                                 (or (plist-get resolved :host) ""))))
+    (user   (read-string (format "1Password username for %s: "
+                                 (or (plist-get resolved :host) ""))
+                         nil nil (user-login-name)))
+    (host   (read-string "1Password host: "))
+    (port   (read-string (format "1Password port for %s@%s (empty for none): "
+                                 (or (plist-get resolved :user) "")
+                                 (or (plist-get resolved :host) ""))))
+    (t      (error "op-auth-source: cannot prompt for unknown field `%s'" field))))
 
 (defvar op-auth-source-backend
   (auth-source-backend
    :source "1password"
    :type '1password
-   :search-function #'op-auth-source-search)
+   :search-function #'op-auth-source-search
+   :create-function #'op-auth-source-create)
   "Auth-source backend for 1Password.")
 
 (defun op-auth-source-backend-parse (entry)
@@ -221,6 +347,27 @@ Returns the label string, or nil if none match."
                 (and (member-ignore-case secret-label field-labels)
                      secret-label))
               op-auth-source--secret-labels)))
+
+(defun op-auth-source--build-template (tag host user port secret)
+  "Build a 1Password Login item JSON template string.
+TAG, HOST, USER and SECRET are required strings.  PORT is included
+as a custom field only when it is a non-empty string."
+  (let* ((base-fields
+          (list `((id . "username") (type . "STRING") (purpose . "USERNAME")
+                  (label . "username") (value . ,user))
+                `((id . "password") (type . "CONCEALED") (purpose . "PASSWORD")
+                  (label . "password") (value . ,secret))
+                `((id . "host") (type . "STRING")
+                  (label . "host") (value . ,host))))
+         (port-field (and port (not (string-empty-p port))
+                          (list `((id . "port") (type . "STRING")
+                                  (label . "port") (value . ,port)))))
+         (fields (vconcat base-fields port-field)))
+    (json-encode
+     `((title . ,host)
+       (category . "LOGIN")
+       (tags . ,(vector tag))
+       (fields . ,fields)))))
 
 (defun op-auth-source--get-secret (item-id account secret-label)
   "Fetch the SECRET-LABEL field for 1Password item ITEM-ID in ACCOUNT.

--- a/op-auth-source.el
+++ b/op-auth-source.el
@@ -134,6 +134,9 @@ with a result plist whose `:save-function' runs `op item create'."
                 :save-function (lambda ()
                                  (op-auth-source--save-item account vault fields))))))
 
+(defconst op-auth-source--redacted-secret "<redacted>"
+  "Placeholder substituted for the password in `*op-error*' diagnostics.")
+
 (defun op-auth-source--save-item (account vault fields)
   "Persist a new 1Password Login item.
 FIELDS is the plist returned by `op-auth-source--prompt-fields'.
@@ -157,7 +160,14 @@ parsed item alist on success.  Signals an error and pops up
                     (plist-get result :stderr)
                     (format "op --account %s item create --vault %s --format json -"
                             account vault)
-                    template)
+                    ;; Pass a redacted template so a failed create never writes
+                    ;; the cleartext password into the `*op-error*' buffer.
+                    (op-auth-source--build-template
+                     op-auth-source-tag
+                     (plist-get fields :host)
+                     (plist-get fields :user)
+                     (plist-get fields :port)
+                     op-auth-source--redacted-secret))
     (json-read-from-string (plist-get result :stdout))))
 
 (defun op-auth-source--resolve-account ()

--- a/op.el
+++ b/op.el
@@ -122,12 +122,18 @@ Each returned item alist has an extra `account_uuid' key."
   "List all 1Password accounts.
 Returns a list of alists with account details.
 Signals an error and pops up stderr if the command fails."
-  (let* ((result (op-run (list "account" "list" "--format" "json")))
-         (exit-code (plist-get result :exit-code))
-         (output (plist-get result :stdout))
-         (stderr (plist-get result :stderr)))
-    (op--check-exit exit-code stderr "op account list --format json")
-    (append (json-read-from-string output) nil)))
+  (op--run-json-list (list "account" "list" "--format" "json")
+                     "op account list --format json"))
+
+(defun op--run-json-list (args command)
+  "Run op with ARGS and return its JSON array output parsed as a list.
+COMMAND is the human-readable invocation used in error messages.
+Signals an error and pops up `*op-error*' if the command fails."
+  (let ((result (op-run args)))
+    (op--check-exit (plist-get result :exit-code)
+                    (plist-get result :stderr)
+                    command)
+    (append (json-read-from-string (plist-get result :stdout)) nil)))
 
 (defun op--list-items (account tag)
   "List 1Password item summaries tagged with TAG for ACCOUNT.

--- a/test/fixtures/account-PXCTHFHEUXV4KPI5J63KDYOBO5-item-create-Op.el-nonexistent.create.com.json
+++ b/test/fixtures/account-PXCTHFHEUXV4KPI5J63KDYOBO5-item-create-Op.el-nonexistent.create.com.json
@@ -1,0 +1,56 @@
+{
+  "id": "36c22vk7mj2hu6xflpfzyikuva",
+  "title": "nonexistent.create.com",
+  "tags": ["OpElTest"],
+  "version": 1,
+  "vault": {
+    "id": "7lzjdhj6eyjrwd54anirntg5qy",
+    "name": "op.el"
+  },
+  "category": "LOGIN",
+  "created_at": "2026-05-07T18:45:08.051709+03:00",
+  "updated_at": "2026-05-07T18:45:08.05171+03:00",
+  "additional_information": "alice",
+  "fields": [
+    {
+      "id": "username",
+      "type": "STRING",
+      "purpose": "USERNAME",
+      "label": "username",
+      "value": "alice",
+      "reference": "op://op.el/nonexistent.create.com/username"
+    },
+    {
+      "id": "password",
+      "type": "CONCEALED",
+      "purpose": "PASSWORD",
+      "label": "password",
+      "value": "topsecret",
+      "reference": "op://op.el/nonexistent.create.com/password",
+      "password_details": {
+        "strength": "WEAK"
+      }
+    },
+    {
+      "id": "notesPlain",
+      "type": "STRING",
+      "purpose": "NOTES",
+      "label": "notesPlain",
+      "reference": "op://op.el/nonexistent.create.com/notesPlain"
+    },
+    {
+      "id": "host",
+      "type": "STRING",
+      "label": "host",
+      "value": "nonexistent.create.com",
+      "reference": "op://op.el/nonexistent.create.com/host"
+    },
+    {
+      "id": "port",
+      "type": "STRING",
+      "label": "port",
+      "value": "587",
+      "reference": "op://op.el/nonexistent.create.com/port"
+    }
+  ]
+}

--- a/test/fixtures/account-PXCTHFHEUXV4KPI5J63KDYOBO5-item-get---API Credentials,Email,Email Duplicate-format-json.json
+++ b/test/fixtures/account-PXCTHFHEUXV4KPI5J63KDYOBO5-item-get---API Credentials,Email,Email Duplicate-format-json.json
@@ -8,7 +8,7 @@
     "name": "Op.el"
   },
   "category": "API_CREDENTIAL",
-  "last_edited_by": "VK6XJVTGTFE3TG6WEQZLYIDWEQ",
+  "last_edited_by": "PXCTHFHEUXV4KPI5J63KDYOBO5",
   "created_at": "2026-03-11T02:50:09Z",
   "updated_at": "2026-03-11T02:50:09Z",
   "fields": [
@@ -74,7 +74,7 @@
     "name": "Op.el"
   },
   "category": "EMAIL_ACCOUNT",
-  "last_edited_by": "VK6XJVTGTFE3TG6WEQZLYIDWEQ",
+  "last_edited_by": "PXCTHFHEUXV4KPI5J63KDYOBO5",
   "created_at": "2026-03-10T11:17:44Z",
   "updated_at": "2026-03-13T06:17:53Z",
   "additional_information": "test@example.com",
@@ -263,7 +263,7 @@
     "name": "Op.el"
   },
   "category": "EMAIL_ACCOUNT",
-  "last_edited_by": "VK6XJVTGTFE3TG6WEQZLYIDWEQ",
+  "last_edited_by": "PXCTHFHEUXV4KPI5J63KDYOBO5",
   "created_at": "2026-03-10T11:17:44Z",
   "updated_at": "2026-03-13T06:16:46Z",
   "additional_information": "test@example.com",

--- a/test/fixtures/account-PXCTHFHEUXV4KPI5J63KDYOBO5-item-get---Email,Email Duplicate-format-json.json
+++ b/test/fixtures/account-PXCTHFHEUXV4KPI5J63KDYOBO5-item-get---Email,Email Duplicate-format-json.json
@@ -8,7 +8,7 @@
     "name": "Op.el"
   },
   "category": "EMAIL_ACCOUNT",
-  "last_edited_by": "VK6XJVTGTFE3TG6WEQZLYIDWEQ",
+  "last_edited_by": "PXCTHFHEUXV4KPI5J63KDYOBO5",
   "created_at": "2026-03-10T11:17:44Z",
   "updated_at": "2026-03-13T06:17:53Z",
   "additional_information": "test@example.com",
@@ -197,7 +197,7 @@
     "name": "Op.el"
   },
   "category": "EMAIL_ACCOUNT",
-  "last_edited_by": "VK6XJVTGTFE3TG6WEQZLYIDWEQ",
+  "last_edited_by": "PXCTHFHEUXV4KPI5J63KDYOBO5",
   "created_at": "2026-03-10T11:17:44Z",
   "updated_at": "2026-03-13T06:16:46Z",
   "additional_information": "test@example.com",

--- a/test/fixtures/account-PXCTHFHEUXV4KPI5J63KDYOBO5-item-list-tags-OpElDuplicate-format-json.json
+++ b/test/fixtures/account-PXCTHFHEUXV4KPI5J63KDYOBO5-item-list-tags-OpElDuplicate-format-json.json
@@ -9,7 +9,7 @@
       "name": "Op.el"
     },
     "category": "EMAIL_ACCOUNT",
-    "last_edited_by": "VK6XJVTGTFE3TG6WEQZLYIDWEQ",
+    "last_edited_by": "PXCTHFHEUXV4KPI5J63KDYOBO5",
     "created_at": "2026-03-10T11:17:44Z",
     "updated_at": "2026-03-13T06:16:46Z",
     "additional_information": "test@example.com"
@@ -24,7 +24,7 @@
       "name": "Op.el"
     },
     "category": "EMAIL_ACCOUNT",
-    "last_edited_by": "VK6XJVTGTFE3TG6WEQZLYIDWEQ",
+    "last_edited_by": "PXCTHFHEUXV4KPI5J63KDYOBO5",
     "created_at": "2026-03-10T11:17:44Z",
     "updated_at": "2026-03-13T06:17:53Z",
     "additional_information": "test@example.com"

--- a/test/fixtures/account-PXCTHFHEUXV4KPI5J63KDYOBO5-item-list-tags-OpElTest-format-json.json
+++ b/test/fixtures/account-PXCTHFHEUXV4KPI5J63KDYOBO5-item-list-tags-OpElTest-format-json.json
@@ -9,7 +9,7 @@
       "name": "Op.el"
     },
     "category": "EMAIL_ACCOUNT",
-    "last_edited_by": "VK6XJVTGTFE3TG6WEQZLYIDWEQ",
+    "last_edited_by": "PXCTHFHEUXV4KPI5J63KDYOBO5",
     "created_at": "2026-03-10T11:17:44Z",
     "updated_at": "2026-03-13T06:16:46Z",
     "additional_information": "test@example.com"
@@ -24,7 +24,7 @@
       "name": "Op.el"
     },
     "category": "API_CREDENTIAL",
-    "last_edited_by": "VK6XJVTGTFE3TG6WEQZLYIDWEQ",
+    "last_edited_by": "PXCTHFHEUXV4KPI5J63KDYOBO5",
     "created_at": "2026-03-11T02:50:09Z",
     "updated_at": "2026-03-11T02:50:09Z"
   },
@@ -38,7 +38,7 @@
       "name": "Op.el"
     },
     "category": "EMAIL_ACCOUNT",
-    "last_edited_by": "VK6XJVTGTFE3TG6WEQZLYIDWEQ",
+    "last_edited_by": "PXCTHFHEUXV4KPI5J63KDYOBO5",
     "created_at": "2026-03-10T11:17:44Z",
     "updated_at": "2026-03-13T06:17:53Z",
     "additional_information": "test@example.com"

--- a/test/fixtures/account-WRYZIV66ZGZOUUQR3SKXFQ753Q-item-get---Op El Test Forge-format-json.json
+++ b/test/fixtures/account-WRYZIV66ZGZOUUQR3SKXFQ753Q-item-get---Op El Test Forge-format-json.json
@@ -8,10 +8,10 @@
     "name": "Employee"
   },
   "category": "LOGIN",
-  "last_edited_by": "IAH6DN35JBCRLIS57PQOMZYK6Y",
+  "last_edited_by": "WRYZIV66ZGZOUUQR3SKXFQ753Q",
   "created_at": "2026-03-15T03:45:00Z",
   "updated_at": "2026-03-15T03:45:00Z",
-  "additional_information": "rgalimov^forge",
+  "additional_information": "jondoe^forge",
   "sections": [
     {
       "id": "add more"
@@ -23,7 +23,7 @@
       "type": "STRING",
       "purpose": "USERNAME",
       "label": "username",
-      "value": "rgalimov^forge",
+      "value": "jondoe^forge",
       "reference": "op://Employee/Op El Test Forge/username"
     },
     {

--- a/test/fixtures/account-WRYZIV66ZGZOUUQR3SKXFQ753Q-item-list-tags-OpElTest-format-json.json
+++ b/test/fixtures/account-WRYZIV66ZGZOUUQR3SKXFQ753Q-item-list-tags-OpElTest-format-json.json
@@ -9,9 +9,9 @@
       "name": "Employee"
     },
     "category": "LOGIN",
-    "last_edited_by": "IAH6DN35JBCRLIS57PQOMZYK6Y",
+    "last_edited_by": "WRYZIV66ZGZOUUQR3SKXFQ753Q",
     "created_at": "2026-03-15T03:45:00Z",
     "updated_at": "2026-03-15T03:45:00Z",
-    "additional_information": "rgalimov^forge"
+    "additional_information": "jondoe^forge"
   }
 ]

--- a/test/fixtures/sanitize.py
+++ b/test/fixtures/sanitize.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Sanitize fixture files by replacing real IDs with mock ones.
+
+Run this after generating fixtures with OP_MODE=verify to ensure
+no real 1Password account IDs leak into the repository.
+"""
+
+import sys
+from pathlib import Path
+
+FIXTURE_DIR = Path(__file__).resolve().parent
+
+# Mapping of real IDs to mock IDs.
+# Add new entries here when additional IDs need sanitizing.
+REPLACEMENTS = {
+    "VK6XJVTGTFE3TG6WEQZLYIDWEQ": "PXCTHFHEUXV4KPI5J63KDYOBO5",
+    "IAH6DN35JBCRLIS57PQOMZYK6Y": "WRYZIV66ZGZOUUQR3SKXFQ753Q",
+    "HQFE3WKP3FDQJA3VHPTEX3HZSI": "PXCTHFHEUXV4KPI5J63KDYOBO5",
+    "rgalimov": "jondoe",
+}
+
+
+def sanitize_file(filepath):
+    """Apply all replacements to a single file. Returns True if modified."""
+    text = filepath.read_text()
+    original = text
+    for real_id, mock_id in REPLACEMENTS.items():
+        text = text.replace(real_id, mock_id)
+    if text != original:
+        filepath.write_text(text)
+        return True
+    return False
+
+
+def main():
+    modified_count = 0
+    file_count = 0
+    for filepath in sorted(FIXTURE_DIR.iterdir()):
+        if filepath.name == Path(__file__).name:
+            continue
+        if not filepath.is_file():
+            continue
+        file_count += 1
+        if sanitize_file(filepath):
+            modified_count += 1
+            print(f"sanitized: {filepath.name}", file=sys.stderr)
+
+    print(
+        f"Checked {file_count} files, sanitized {modified_count}.",
+        file=sys.stderr,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/test/op-auth-source-test.el
+++ b/test/op-auth-source-test.el
@@ -289,7 +289,27 @@
 			nil
 			"topsecret")
 		       :to-equal
-		       "{\"title\":\"imap.example.com\",\"category\":\"LOGIN\",\"tags\":[\"emacs-auth-source\"],\"fields\":[{\"id\":\"username\",\"type\":\"STRING\",\"purpose\":\"USERNAME\",\"label\":\"username\",\"value\":\"bob@example.com\"},{\"id\":\"password\",\"type\":\"CONCEALED\",\"purpose\":\"PASSWORD\",\"label\":\"password\",\"value\":\"topsecret\"},{\"id\":\"host\",\"type\":\"STRING\",\"label\":\"host\",\"value\":\"imap.example.com\"}]}")))
+		       "{\"title\":\"imap.example.com\",\"category\":\"LOGIN\",\"tags\":[\"emacs-auth-source\"],\"fields\":[{\"id\":\"username\",\"type\":\"STRING\",\"purpose\":\"USERNAME\",\"label\":\"username\",\"value\":\"bob@example.com\"},{\"id\":\"password\",\"type\":\"CONCEALED\",\"purpose\":\"PASSWORD\",\"label\":\"password\",\"value\":\"topsecret\"},{\"id\":\"host\",\"type\":\"STRING\",\"label\":\"host\",\"value\":\"imap.example.com\"}]}"))
+
+	   (it "when given extra fields should append them as string fields after the base fields"
+	       (expect (op-auth-source--build-template
+			"emacs-auth-source"
+			"smtp.example.com"
+			"alice@example.com"
+			"587"
+			"p@ss"
+			'(:description "primary mail"))
+		       :to-equal
+		       "{\"title\":\"smtp.example.com\",\"category\":\"LOGIN\",\"tags\":[\"emacs-auth-source\"],\"fields\":[{\"id\":\"username\",\"type\":\"STRING\",\"purpose\":\"USERNAME\",\"label\":\"username\",\"value\":\"alice@example.com\"},{\"id\":\"password\",\"type\":\"CONCEALED\",\"purpose\":\"PASSWORD\",\"label\":\"password\",\"value\":\"p@ss\"},{\"id\":\"host\",\"type\":\"STRING\",\"label\":\"host\",\"value\":\"smtp.example.com\"},{\"id\":\"port\",\"type\":\"STRING\",\"label\":\"port\",\"value\":\"587\"},{\"id\":\"description\",\"type\":\"STRING\",\"label\":\"description\",\"value\":\"primary mail\"}]}")))
+
+ (describe "--extra-fields"
+	   (it "when fields include keys beyond the base set should return only the extras"
+	       (expect (op-auth-source--extra-fields '(:host "h" :user "u" :port "587" :secret "s" :description "primary mail"))
+		       :to-equal '(:description "primary mail")))
+
+	   (it "when fields contain only base keys should return nil"
+	       (expect (op-auth-source--extra-fields '(:host "h" :user "u" :port "587" :secret "s"))
+		       :to-be nil)))
 
  (describe "--get-secret"
 	   (it "when called via op.py should return the password"

--- a/test/op-auth-source-test.el
+++ b/test/op-auth-source-test.el
@@ -251,6 +251,37 @@
 			'((fields . [((label . "username") (value . "me"))])))
 		       :to-equal nil)))
 
+ (describe "--build-template"
+	   (it "when given full spec should emit a deterministic login json string"
+	       (expect (op-auth-source--build-template
+			"emacs-auth-source"
+			"smtp.example.com"
+			"alice@example.com"
+			"587"
+			"p@ss")
+		       :to-equal
+		       "{\"title\":\"smtp.example.com\",\"category\":\"LOGIN\",\"tags\":[\"emacs-auth-source\"],\"fields\":[{\"id\":\"username\",\"type\":\"STRING\",\"purpose\":\"USERNAME\",\"label\":\"username\",\"value\":\"alice@example.com\"},{\"id\":\"password\",\"type\":\"CONCEALED\",\"purpose\":\"PASSWORD\",\"label\":\"password\",\"value\":\"p@ss\"},{\"id\":\"host\",\"type\":\"STRING\",\"label\":\"host\",\"value\":\"smtp.example.com\"},{\"id\":\"port\",\"type\":\"STRING\",\"label\":\"port\",\"value\":\"587\"}]}"))
+
+	   (it "when port is empty should omit the port field"
+	       (expect (op-auth-source--build-template
+			"emacs-auth-source"
+			"imap.example.com"
+			"bob@example.com"
+			""
+			"topsecret")
+		       :to-equal
+		       "{\"title\":\"imap.example.com\",\"category\":\"LOGIN\",\"tags\":[\"emacs-auth-source\"],\"fields\":[{\"id\":\"username\",\"type\":\"STRING\",\"purpose\":\"USERNAME\",\"label\":\"username\",\"value\":\"bob@example.com\"},{\"id\":\"password\",\"type\":\"CONCEALED\",\"purpose\":\"PASSWORD\",\"label\":\"password\",\"value\":\"topsecret\"},{\"id\":\"host\",\"type\":\"STRING\",\"label\":\"host\",\"value\":\"imap.example.com\"}]}"))
+
+	   (it "when port is nil should omit the port field"
+	       (expect (op-auth-source--build-template
+			"emacs-auth-source"
+			"imap.example.com"
+			"bob@example.com"
+			nil
+			"topsecret")
+		       :to-equal
+		       "{\"title\":\"imap.example.com\",\"category\":\"LOGIN\",\"tags\":[\"emacs-auth-source\"],\"fields\":[{\"id\":\"username\",\"type\":\"STRING\",\"purpose\":\"USERNAME\",\"label\":\"username\",\"value\":\"bob@example.com\"},{\"id\":\"password\",\"type\":\"CONCEALED\",\"purpose\":\"PASSWORD\",\"label\":\"password\",\"value\":\"topsecret\"},{\"id\":\"host\",\"type\":\"STRING\",\"label\":\"host\",\"value\":\"imap.example.com\"}]}")))
+
  (describe "--get-secret"
 	   (it "when called via op.py should return the password"
 	       (expect (op-auth-source--get-secret "sre4q66mawycb5dzmm7ka7kblm" "PXCTHFHEUXV4KPI5J63KDYOBO5" "password")
@@ -367,12 +398,109 @@
 	       (expect (auth-source-search :host "imap.example.com"
 					   :user "test@example.com"
 					   :port '("25" "587"))
-		       :to-be nil)))
+		       :to-be nil))
+
+	   (it "when no items match and :create t should dispatch to create-function and persist via op item create"
+	       (spy-on 'op-auth-source--resolve-account
+		       :and-return-value "PXCTHFHEUXV4KPI5J63KDYOBO5")
+	       (spy-on 'op-auth-source--resolve-vault
+		       :and-return-value "Op.el")
+	       (spy-on 'op-run :and-call-through)
+	       (let ((string-prompts '("alice" "587"))
+		     (passwd-prompts '("topsecret")))
+		 (cl-letf (((symbol-function 'read-string)
+			    (lambda (&rest _) (pop string-prompts)))
+			   ((symbol-function 'read-passwd)
+			    (lambda (&rest _) (pop passwd-prompts))))
+		   (let ((entry (car (auth-source-search
+				      :host "nonexistent.create.com"
+				      :create t))))
+		     (expect 'op-auth-source--resolve-account :to-have-been-called)
+		     (expect 'op-auth-source--resolve-vault :to-have-been-called)
+		     (expect (alist-get 'title (funcall (plist-get entry :save-function)))
+			     :to-equal "nonexistent.create.com")
+		     (expect 'op-run :to-have-been-called-with
+			     '("--account" "PXCTHFHEUXV4KPI5J63KDYOBO5"
+			       "item" "create"
+			       "--vault" "Op.el"
+			       "--format" "json"
+			       "-")
+			     "{\"title\":\"nonexistent.create.com\",\"category\":\"LOGIN\",\"tags\":[\"OpElTest\"],\"fields\":[{\"id\":\"username\",\"type\":\"STRING\",\"purpose\":\"USERNAME\",\"label\":\"username\",\"value\":\"alice\"},{\"id\":\"password\",\"type\":\"CONCEALED\",\"purpose\":\"PASSWORD\",\"label\":\"password\",\"value\":\"topsecret\"},{\"id\":\"host\",\"type\":\"STRING\",\"label\":\"host\",\"value\":\"nonexistent.create.com\"},{\"id\":\"port\",\"type\":\"STRING\",\"label\":\"port\",\"value\":\"587\"}]}"))))))
+
+ (describe "--prompt-for-field"
+	   (it "when given an unknown field should signal an error"
+	       (expect (op-auth-source--prompt-for-field 'unknown nil)
+		       :to-throw 'error)))
+
+ (describe "create"
+	   (before-each
+	    (spy-on 'op-auth-source--resolve-account
+		    :and-return-value "PXCTHFHEUXV4KPI5J63KDYOBO5")
+	    (spy-on 'op-auth-source--resolve-vault
+		    :and-return-value "Op.el"))
+
+	   (it "when spec provides every required field should return a result without prompting"
+	       (cl-letf (((symbol-function 'read-string)
+			  (lambda (&rest _) (error "read-string must not be called")))
+			 ((symbol-function 'read-passwd)
+			  (lambda (&rest _) (error "read-passwd must not be called"))))
+		 (expect (op-auth-source-create
+			  :host "smtp.example.com"
+			  :user "alice@example.com"
+			  :port "587"
+			  :secret "p@ss"
+			  :create t
+			  :backend op-auth-source-backend)
+			 :to-smart-match
+			 '((:host "smtp.example.com"
+				  :user "alice@example.com"
+				  :port "587"
+				  :account "PXCTHFHEUXV4KPI5J63KDYOBO5"
+				  :secret op-test-any
+				  :save-function op-test-any)))))
+
+	   (it "when fields are missing should prompt and use the entered values"
+	       (let ((string-prompts '("smtp.test.com" "alice" "587"))
+		     (passwd-prompts '("topsecret")))
+		 (cl-letf (((symbol-function 'read-string)
+			    (lambda (&rest _) (pop string-prompts)))
+			   ((symbol-function 'read-passwd)
+			    (lambda (&rest _) (pop passwd-prompts))))
+		   (let ((entry (car (op-auth-source-create
+				      :create t
+				      :backend op-auth-source-backend))))
+		     (expect entry
+			     :to-smart-match
+			     '(:host "smtp.test.com"
+				     :user "alice"
+				     :port "587"
+				     :account "PXCTHFHEUXV4KPI5J63KDYOBO5"
+				     :secret op-test-any
+				     :save-function op-test-any))
+		     (expect (funcall (plist-get entry :secret))
+			     :to-equal "topsecret")))))
+
+	   (it "when save-function is called and op fails should signal an error"
+	       (let ((entry (car (op-auth-source-create
+				  :host "create-fail.example.com"
+				  :user "alice@example.com"
+				  :port "443"
+				  :secret "topsecret"
+				  :create t
+				  :backend op-auth-source-backend))))
+		 (expect (funcall (plist-get entry :save-function))
+			 :to-throw 'error
+			 '("op --account PXCTHFHEUXV4KPI5J63KDYOBO5 item create --vault Op.el --format json - failed (exit 1)")))))
 
  (describe "backend-parse"
 	   (it "when given 1password symbol should return a backend"
 	       (let ((backend (op-auth-source-backend-parse '1password)))
 		 (expect backend :not :to-be nil)))
+
+	   (it "when given 1password symbol should return a backend with create-function wired"
+	       (let ((backend (op-auth-source-backend-parse '1password)))
+		 (expect (slot-value backend 'create-function)
+			 :to-equal #'op-auth-source-create)))
 
 	   (it "when given an unrelated entry should return nil"
 	       (expect (op-auth-source-backend-parse "~/.authinfo") :to-be nil)

--- a/test/op-auth-source-test.el
+++ b/test/op-auth-source-test.el
@@ -490,7 +490,20 @@
 				  :backend op-auth-source-backend))))
 		 (expect (funcall (plist-get entry :save-function))
 			 :to-throw 'error
-			 '("op --account PXCTHFHEUXV4KPI5J63KDYOBO5 item create --vault Op.el --format json - failed (exit 1)")))))
+			 '("op --account PXCTHFHEUXV4KPI5J63KDYOBO5 item create --vault Op.el --format json - failed (exit 1)"))))
+
+	   (it "when save-function fails should not write the cleartext password into *op-error*"
+	       (let ((entry (car (op-auth-source-create
+				  :host "create-fail.example.com"
+				  :user "alice@example.com"
+				  :port "443"
+				  :secret "topsecret"
+				  :create t
+				  :backend op-auth-source-backend))))
+		 (ignore-errors (funcall (plist-get entry :save-function)))
+		 (with-current-buffer "*op-error*"
+		   (expect (buffer-string) :not :to-match "topsecret")
+		   (expect (buffer-string) :to-match "<redacted>")))))
 
  (describe "backend-parse"
 	   (it "when given 1password symbol should return a backend"

--- a/test/op-auth-source-test.el
+++ b/test/op-auth-source-test.el
@@ -96,6 +96,15 @@
 		 (expect (op-auth-source--field-match-p item :user "alice@example.com")
 			 :to-be nil))))
 
+ (describe "--value-to-string"
+	   (it "when given a list pattern should resolve to the first element"
+	       (expect (op-auth-source--value-to-string (quote ("587" "465")))
+		       :to-equal "587"))
+
+	   (it "when given a symbol should return its name"
+	       (expect (op-auth-source--value-to-string (quote imap))
+		       :to-equal "imap")))
+
  (describe "--list-accounts"
 	   (it "when called via op.py should return a list of account alists"
 	       (expect (op--list-accounts)


### PR DESCRIPTION
## Summary
- The `op-auth-source` backend was read-only — packages calling `(auth-source-search ... :create t)` against a missing host silently got `nil` instead of being able to save the credential to 1Password.
- Wires the auth-source `:create-function` slot to a new `op-auth-source-create` that prompts for the missing fields and runs `op item create` with a JSON template piped on stdin.
- Drive-by: tracks `test/fixtures/sanitize.py` (it was previously untracked) and re-running it picks up stale `last_edited_by` UUID leakage in 6 older fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)