### PR TITLE
Pipe stdin to op via cat so `item get -` works

### DIFF
--- a/bin/op.py
+++ b/bin/op.py
@@ -13,6 +13,7 @@ import json
 import logging
 import os
 import signal
+import stat
 import subprocess
 import sys
 import time
@@ -103,6 +104,13 @@ def fixture_path(argv):
         extra = args_to_suffix(rest[1:])
         ext = "json" if "--format" in args and "json" in args else "txt"
         if item_id == "-":
+            if not stat.S_ISFIFO(os.fstat(sys.stdin.fileno()).st_mode):
+                # Mimics real op: stdin must be a pipe when item id is '-'.
+                print(
+                    '[ERROR] "-" isn\'t an item. Specify the item with its UUID, name, or domain.',
+                    file=sys.stderr,
+                )
+                sys.exit(1)
             stdin_data = sys.stdin.read()
             items = json.loads(stdin_data)
             titles = ",".join(sorted(i["title"] for i in items))

--- a/op.el
+++ b/op.el
@@ -240,7 +240,7 @@ Returns a plist (:exit-code N :stdout STRING :stderr STRING)."
          :connection-type 'pty
          :filter #'op--filter-pty)
         op--pty-output "")
-  (process-send-string op--pty-process "stty -echo && PS1='' && PS2=''\n")
+  (process-send-string op--pty-process "stty -echo && PS1='' && PS2='' && set -o pipefail\n")
   (accept-process-output op--pty-process op--pty-startup-timeout-seconds)
   (setq op--pty-output ""))
 
@@ -277,6 +277,10 @@ does not respond, escalates to SIGKILL and discards the PTY."
 COMMAND-ID is a unique tag used to delimit output.
 ARGS is a list of argument strings for the op executable.
 Optional STDIN-DATA, if non-nil, is written to a temp file and piped as stdin.
+The op CLI requires stdin to be a real pipe when item id is `-', so the
+shell command pipes the temp file through `cat' rather than using `<file'
+redirection.  Combined with `pipefail' set in `op--start-pty', the exit
+code reflects op's failure (not cat's success).
 Returns the shell command string."
   (let ((begin-tag (format "__OP_BEGIN_%s__" command-id))
         (end-tag (format "__OP_END_%s__" command-id))
@@ -286,13 +290,13 @@ Returns the shell command string."
                         (write-region stdin-data nil file nil 'silent)
                         file)))
         (quoted-args (mapconcat #'shell-quote-argument args " ")))
-    (format "printf '\\n%s\\n' && %s %s%s 2>%s; printf '\\n%s:%%d\\n' \"$?\"\n"
+    (format "printf '\\n%s\\n' && %s%s %s 2>%s; printf '\\n%s:%%d\\n' \"$?\"\n"
             begin-tag
+            (if stdin-file
+                (format "cat %s | " (shell-quote-argument stdin-file))
+              "")
             (shell-quote-argument op-executable)
             quoted-args
-            (if stdin-file
-                (format " <%s" (shell-quote-argument stdin-file))
-              "")
             (shell-quote-argument stderr-file)
             end-tag)))
 


### PR DESCRIPTION
## Problem

Running `auth-source-search` with the `op-auth-source` backend against real `op` fails with:

```
[ERROR] "-" isn't an item. Specify the item with its UUID, name, or domain.
```

`op item get -` reads ids from stdin, but the CLI only accepts `-` when stdin is a real pipe (FIFO). `op-run` was feeding stdin via `<file` shell redirection, which makes stdin a regular file — op rejects it.

The mock `bin/op.py` read stdin unconditionally, so the unit tests passed and the bug only surfaced in real use.

## Change

- `op--make-run-shell-command` now builds `cat <stdin-file> | op …` instead of `op … <stdin-file`.
- `op--start-pty` enables `pipefail` so the captured exit code reflects op's failure, not cat's success.
- `bin/op.py` now `fstat`s stdin and rejects `-` unless it is a FIFO, with the same error message real op emits — so future regressions of this shape fail in mock-mode tests too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)